### PR TITLE
Fixes #32 | Map not displaying on listings index page

### DIFF
--- a/views/listings/index.ejs
+++ b/views/listings/index.ejs
@@ -313,7 +313,7 @@
 
         // Initialize cluster map with all listings
         window.addEventListener('load', function () {
-            let allListingsData = <% - JSON.stringify(allListings) %> ;
+            let allListingsData = <%- JSON.stringify(allListings) %>;
             console.log("Listings data:", allListingsData.length, "listings");
 
             // Check if Leaflet is loaded


### PR DESCRIPTION
Fixes #32

Fixed syntax error in EJS template where space in `<% - JSON.stringify()` 
prevented listings data from being properly embedded in JavaScript.
Changed to `<%- JSON.stringify()` (removed space).

This resolves the issue where the cluster map was not working on the 
main listings page while working correctly on individual listing pages.